### PR TITLE
Feat/auth logas

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,18 @@ var options = {
 var api = new callr.api('login', 'password', options);
 ```
 
+## Set Login As after Init
+
+```javascript
+var callr = require('callr');
+var api = new callr.api('login', 'password');
+...
+
+api.setLoginAs('user', '<login>'); // available types: user, account
+                                   // available targets: <login> for type user,
+                                   // <hash> for type account
+```
+
 ## API return value management
 > Set your success/error callback to get data returned by the API
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 sdk-nodejs
 ==========
 
-SDK in NodeJS for CALLR API  
-For more examples see the the nodejs examples (https://github.com/THECALLR/examples-nodejs) repo.  
+SDK in NodeJS for CALLR API
+For more examples see the the nodejs examples (https://github.com/THECALLR/examples-nodejs) repo.
 
 ## Quick start
 Install via NPM
@@ -17,6 +17,20 @@ Or get sources from Github
 var callr = require('callr');
 
 var api = new callr.api('login', 'password');
+```
+
+## Init with Login As
+
+```javascript
+var callr = require('callr');
+var options = {
+    loginas: {
+        type: 'user',       // available types: user, account
+        target: '<login>'   // available targets: <login> for type user,
+    }                       // <hash> for type account
+}
+
+var api = new callr.api('login', 'password', options);
 ```
 
 ## API return value management

--- a/lib/callr.js
+++ b/lib/callr.js
@@ -9,6 +9,12 @@ exports.api = function(login, password, config) {
 
 	var SDK_VERSION = "1.1";
 
+	// var LogAs types
+	var loginAsTypes = {
+		user: 'user.login',
+		account: 'account.hash'
+	}
+
 	// allow api url to be changed
 	this.apiUrl = "https://api.callr.com/json-rpc/v1.1/";
 
@@ -48,6 +54,15 @@ exports.api = function(login, password, config) {
 			"Content-Length": Buffer.byteLength(json)
 		};
 
+		// Login As support
+		if (config && config.hasOwnProperty('loginas')) {
+			assert.equal(typeof (config.loginas.type), 'string', "loginas.type must be a string");
+			assert.ok(config.loginas.type.toLowerCase() in loginAsTypes, `loginas type must be one of "${Object.keys(loginAsTypes)}"`);
+			assert.equal(typeof (config.loginas.target), 'string', "loginas.target must be a string")
+
+			options.headers['CALLR-Login-As'] = `${loginAsTypes[config.loginas.type.toLowerCase()]} ${config.loginas.target}`;
+		}
+
 		// Proxy agent support
 		if (config && config.hasOwnProperty('proxyAgent')) {
 			options.agent = config.proxyAgent;
@@ -66,10 +81,10 @@ exports.api = function(login, password, config) {
 					}));
 				}
 				res.on('data', function(data) {
-					  buf += data;
+					buf += data;
 				});
 				res.on('end', function() {
-					  parseData(buf.toString(), callback);
+					parseData(buf.toString(), callback);
 				});
 			});
 

--- a/lib/callr.js
+++ b/lib/callr.js
@@ -24,6 +24,15 @@ exports.api = function(login, password, config) {
 		this.error = false;
 	};
 
+	// Set login As options
+	this.setLoginAs = function (type, target) {
+		if(config === undefined) config = {};
+		config.loginas = {
+			type: type,
+			target: target
+		}
+	}
+
 	// Send a request to THECALLR webservice
 	this.call = function(method) {
 		assert.equal(typeof(method), 'string', "argument 'method' must be a string");


### PR DESCRIPTION
\+ added login as support to nodejs sdk
\+ updated readme with example usage

logas supports 2 types:  
- `user`: username of the account to login as
- `account` : account hash of the account to login as