### PR TITLE
Deprecate v1 (JSON-RPC) SDK — migrate to Callr REST API v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,22 @@
 >
 > Your existing API credentials work with REST API v2 — **no new keys required**.
 >
-> **Using REST API v2 today:** v2 is a standard REST API described by an OpenAPI 3.1 specification — call it directly with any HTTP client, or generate a fully-typed client for your language with [OpenAPI Generator](https://openapi-generator.tech/).
+> **Official Callr REST API v2 SDKs are coming in the near future.** In the meantime, you can call the REST API directly, or generate a client from the OpenAPI 3.1 spec (see **Generate a REST API v2 client today** below).
+
+---
+
+## Generate a REST API v2 client today
+
+**An official Callr REST API v2 SDK for Node.js / TypeScript is coming soon.** Until then, generate a fully-typed client from the [OpenAPI 3.1 spec](https://api.callr.com/v2.0/openapi.json) with [OpenAPI Generator](https://openapi-generator.tech/) (requires v7.x+ for OpenAPI 3.1):
+
+```bash
+docker run --rm -v "$PWD:/local" openapitools/openapi-generator-cli generate \
+  -g typescript-axios \
+  -i https://api.callr.com/v2.0/openapi.json \
+  -o /local/callr-v2-node
+```
+
+Authenticate with your API Key via the `x-api-key` header (or HTTP Basic: Account SID + API Key). The base URL `https://api.callr.com/v2.0` is baked into the generated client — see its generated `docs/` for the available endpoints.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,20 @@
+> ## ⚠️ DEPRECATED — Callr API v1 (JSON-RPC)
+>
+> This SDK targets the **legacy Callr JSON-RPC API (v1)**, which is **deprecated** and **will be shut down on 30 June 2027**. After that date this SDK will stop working.
+>
+> **➡️ Please migrate to the new Callr REST API v2.**
+>
+> - 📘 **Migration guide (JSON-RPC → REST API v2):** https://docs.callr.com/reference/migrating-from-json-rpc-v1
+> - 📣 **What's new in REST API v2:** https://docs.callr.com/changelog/rest-api-v2-is-here
+> - 🌐 **REST API v2 base URL:** `https://api.callr.com/v2.0`
+> - ✉️ **Questions / migration help:** support@callr.com
+>
+> Your existing API credentials work with REST API v2 — **no new keys required**.
+>
+> **Using REST API v2 today:** v2 is a standard REST API described by an OpenAPI 3.1 specification — call it directly with any HTTP client, or generate a fully-typed client for your language with [OpenAPI Generator](https://openapi-generator.tech/).
+
+---
+
 sdk-nodejs
 ==========
 

--- a/lib/callr.js
+++ b/lib/callr.js
@@ -19,6 +19,9 @@ exports.userSessionAuth = function(sessionKey){
 	return `Session ${sessionKey}`;
 }
 
+/**
+ * @deprecated Deprecated: this SDK targets the legacy Callr JSON-RPC API (v1), which will be shut down on 2027-06-30. Migrate to the Callr REST API v2: https://docs.callr.com/reference/migrating-from-json-rpc-v1
+ */
 exports.api = function(authorization, config) {
 	"use strict";
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "callr",
     "version": "2.0.0",
-    "description": "Nodejs SDK for CALLR API",
+    "description": "[DEPRECATED — shutting down 2027-06-30, migrate to Callr REST API v2] Legacy Callr JSON-RPC API (v1) Node.js SDK. See https://docs.callr.com/reference/migrating-from-json-rpc-v1",
     "keywords": [
         "callr",
         "thecallr",


### PR DESCRIPTION
## Deprecate the v1 (JSON-RPC) SDK in favor of the Callr REST API v2

This SDK targets the legacy Callr JSON-RPC API (v1), which is deprecated and scheduled to shut down on **30 June 2027**.

**Changes**
- **README:** prominent deprecation banner with the sunset date and links to the migration guide + v2 announcement; notes that official REST API v2 SDKs are coming soon; adds a one-command OpenAPI Generator recipe for an interim typed client.
- **Package metadata** flagged as deprecated where the registry supports it (composer `abandoned`, PyPI `Inactive` classifier, gem `post_install_message`, Go module `// Deprecated:`, npm/Java/.NET descriptions).
- **IDE-visible deprecation markers** on the client surface (`@deprecated` / `@Deprecated` / `[Obsolete]` / `@available(*, deprecated:)` / Go `// Deprecated:`).

**Still needs a maintainer (publish/admin access):** registry-level deprecation (`npm deprecate`, NuGet deprecate, a final RubyGems/PyPI/Maven release), updating the GitHub repo description + adding a `deprecated` topic, a pinned issue, and archiving the repo after merge.

Migration guide: https://docs.callr.com/reference/migrating-from-json-rpc-v1

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017gqHWDR4qfY5bzundxmBev

---
_Generated by [Claude Code](https://claude.ai/code/session_017gqHWDR4qfY5bzundxmBev)_